### PR TITLE
bugfix/fivetran-utils-ref-removal

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'dbt_package_automations'
-version: '1.0.0'
+version: '0.1.1'
 config-version: 2
 
 target-path: "target"  # directory which will store compiled SQL files

--- a/generate_columns.sh
+++ b/generate_columns.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 mkdir -p $1/macros
-dbt run-operation fivetran_utils.generate_columns_macro --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 > $1/macros/get_$5_columns.sql
+dbt run-operation dbt_package_automations.generate_columns_macro --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 > $1/macros/get_$5_columns.sql

--- a/generate_models.sh
+++ b/generate_models.sh
@@ -29,7 +29,7 @@ final as (
     select " >> $1/models/$2__$5.sql
     
 
-dbt run-operation fivetran_utils.get_column_names_only --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 >> $1/models/$2__$5.sql
+dbt run-operation dbt_package_automations.get_column_names_only --args '{"table_name": "'$5'", "schema_name": "'$4'", "database_name":"'$3'"}' | tail -n +2 >> $1/models/$2__$5.sql
     
     
 echo "    from fields


### PR DESCRIPTION
# Issue that will be resolved with this PR
The project currently still references `fivetran_utils` at points within the macros. This causes the macros to fail due to incorrect referencing. This PR adjusts this to reference itself instead.

# How was this tested?
This was tested and leveraged when developing the Google Ads Ad Reporting updates.