### PR TITLE
remove line breaks from staging_models_automation output

### DIFF
--- a/macros/staging_models_automation.sql
+++ b/macros/staging_models_automation.sql
@@ -19,6 +19,6 @@
 
 {% endfor %}
 
-{{ log(columns_array|join(' && \n') + ' && \n' + models_array|join(' && \n'), info=True) }}
+{{ log(columns_array|join(' && ') + ' && ' + models_array|join(' && '), info=True) }}
 
 {% endmacro %} 


### PR DESCRIPTION
at least in vscode, the terminal does not like it when i paste in the output of the staging model/column automation script. this is because we add line breaks, so i've removed them if this continues to be an issue