### PR TITLE
CHANGELOG change formatted_package_name_here to `package_name_here`

### DIFF
--- a/new_package_files/CHANGELOG.md
+++ b/new_package_files/CHANGELOG.md
@@ -1,5 +1,5 @@
 # dbt_package_name_here v0.1.0
-This is the initial release of the formatted_package_name_here dbt package!
+This is the initial release of the `package_name_here` dbt package!
 
 # 📣 What does this dbt package do?
 


### PR DESCRIPTION
In the new AWS Cloud Cost package, the automation created a changelog that said:

> This is the initial release of the formatted_aws_cloud_cost dbt package!

When it should be

> This is the initial release of the `aws_cloud_cost` dbt package!

Opening this PR to test out with the next new package, but lmk if this isn't how the automation works @fivetran-catfritz @fivetran-joemarkiewicz 